### PR TITLE
 Implement collection of Agent Version and OS Information (#12)

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -311,6 +311,10 @@ func getTransactionItems(transaction_id string) (TransactionDetail, error) {
 
 // saveExecution sends the execution details to the server.
 func saveExecution(success bool, machineId, hostname, details string, processed, sent int) error {
+	err := util.ParseOSRelease()
+	if err != nil {
+		return fmt.Errorf("error while reading /etc/os-release file: %v", err)
+	}
 	response, err := resty.New().R().
 		SetHeader("Content-Type", "application/json").
 		SetBody(map[string]interface{}{
@@ -321,6 +325,8 @@ func saveExecution(success bool, machineId, hostname, details string, processed,
 			"success":                success,
 			"transactions_processed": processed,
 			"transactions_sent":      sent,
+			"agent_version":          agentVersion,
+			"os":                     util.Release.PrettyName,
 		}).
 		Post(viper.GetString("server.url") + "/v1/executions")
 

--- a/cmd/executions.go
+++ b/cmd/executions.go
@@ -20,6 +20,8 @@ type Execution struct {
 	Details               string     `json:"details,omitempty"`
 	TransactionsProcessed int        `json:"transactions_processed,omitempty"`
 	TransactionsSent      int        `json:"transactions_sent,omitempty"`
+	AgentVersion          string     `json:"agent_version,omitempty"`
+	OS                    string     `json:"os,omitempty"`
 }
 
 // executionsCmd represents the executions command
@@ -38,19 +40,21 @@ var executionsCmd = &cobra.Command{
 		}
 
 		if len(savedExecutions) > 0 {
-			fmt.Println("| ID | Host | Success | Executed | Processed | Sent | Details |")
-			fmt.Println("|----|------|---------|----------|-----------|------|---------|")
+			fmt.Println("| ID | Host | Success | Executed | Processed | Sent | Details | Agent | OS |")
+			fmt.Println("|----|------|---------|----------|-----------|------|---------|-------|----|")
 		}
 
 		for _, exec := range savedExecutions {
-			fmt.Printf("| %s | %s | %v | %v | %v | %v | %v |\n",
+			fmt.Printf("| %s | %s | %v | %v | %v | %v | %v | %s | %s |\n",
 				exec.ExecutionID,
 				exec.Hostname,
 				exec.Success,
 				exec.ExecutedAt.Format(time.RFC3339),
 				exec.TransactionsProcessed,
 				exec.TransactionsSent,
-				exec.Details)
+				exec.Details,
+				exec.AgentVersion,
+				exec.OS)
 		}
 	},
 }

--- a/util/osrelease.go
+++ b/util/osrelease.go
@@ -1,0 +1,157 @@
+// Package osrelease parse /etc/os-release
+// MIT License
+//
+// Copyright (c) 2021 Dániel Görbe
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// More about the os-release: https://www.linux.org/docs/man5/os-release.html
+package util
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Path contains the default path to the os-release file
+var Path = "/etc/os-release"
+
+var Release OSRelease
+
+type OSRelease struct {
+	Name             string
+	Version          string
+	ID               string
+	IDLike           string
+	PrettyName       string
+	VersionID        string
+	HomeURL          string
+	DocumentationURL string
+	SupportURL       string
+	BugReportURL     string
+	PrivacyPolicyURL string
+	VersionCodename  string
+	UbuntuCodename   string
+	ANSIColor        string
+	CPEName          string
+	BuildID          string
+	Variant          string
+	VariantID        string
+	Logo             string
+}
+
+// getLines read the OSReleasePath and return it line by line.
+// Empty lines and comments (beginning with a "#") are ignored.
+func getLines() ([]string, error) {
+
+	output, err := os.ReadFile(Path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %s", Path, err)
+	}
+
+	lines := make([]string, 0)
+
+	for _, line := range strings.Split(string(output), "\n") {
+
+		switch true {
+		case line == "":
+			continue
+		case []byte(line)[0] == '#':
+			continue
+		}
+
+		lines = append(lines, line)
+	}
+
+	return lines, nil
+}
+
+// parseLine parse a single line.
+// Return key, value, error (if any)
+func parseLine(line string) (string, string, error) {
+
+	subs := strings.SplitN(line, "=", 2)
+
+	if len(subs) != 2 {
+		return "", "", fmt.Errorf("invalid length of the substrings: %d", len(subs))
+	}
+
+	return subs[0], strings.Trim(subs[1], "\"'"), nil
+}
+
+// ParseOSRelease parses the os-release file pointing to by Path.
+// The fields are saved into the Release global variable.
+func ParseOSRelease() error {
+
+	lines, err := getLines()
+	if err != nil {
+		return fmt.Errorf("failed to get lines of %s: %s", Path, err)
+	}
+
+	for i := range lines {
+
+		key, value, err := parseLine(lines[i])
+		if err != nil {
+			return fmt.Errorf("failed to parse line '%s': %s", lines[i], err)
+		}
+
+		switch key {
+		case "NAME":
+			Release.Name = value
+		case "VERSION":
+			Release.Version = value
+		case "ID":
+			Release.ID = value
+		case "ID_LIKE":
+			Release.IDLike = value
+		case "PRETTY_NAME":
+			Release.PrettyName = value
+		case "VERSION_ID":
+			Release.VersionID = value
+		case "HOME_URL":
+			Release.HomeURL = value
+		case "DOCUMENTATION_URL":
+			Release.DocumentationURL = value
+		case "SUPPORT_URL":
+			Release.SupportURL = value
+		case "BUG_REPORT_URL":
+			Release.BugReportURL = value
+		case "PRIVACY_POLICY_URL":
+			Release.PrivacyPolicyURL = value
+		case "VERSION_CODENAME":
+			Release.VersionCodename = value
+		case "UBUNTU_CODENAME":
+			Release.UbuntuCodename = value
+		case "ANSI_COLOR":
+			Release.ANSIColor = value
+		case "CPE_NAME":
+			Release.CPEName = value
+		case "BUILD_ID":
+			Release.BuildID = value
+		case "VARIANT":
+			Release.Variant = value
+		case "VARIANT_ID":
+			Release.VariantID = value
+		case "LOGO":
+			Release.Logo = value
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pull request addresses issue [#12](https://github.com/txlog/agent/issues/12) by adding functionality to collect the agent version and OS information during each execution. This enhancement will help in identifying outdated agents and gathering relevant OS details.